### PR TITLE
fixed train2_label to train1_label for envs

### DIFF
--- a/model/make_envs.py
+++ b/model/make_envs.py
@@ -22,7 +22,7 @@ def env_covariate_shift_MNIST():
     envs = []
 
     envs.append({'images':torch.tensor(train1_input,dtype = torch.float32), 
-                 'labels':torch.tensor(train2_label,dtype = torch.float32)})
+                 'labels':torch.tensor(train1_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(train2_input,dtype = torch.float32),
                  'labels':torch.tensor(train2_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(test1_input,dtype = torch.float32), 
@@ -50,7 +50,7 @@ def env_mechanism_shift_MNIST():
     envs = []
 
     envs.append({'images':torch.tensor(train1_input,dtype = torch.float32), 
-                 'labels':torch.tensor(train2_label,dtype = torch.float32)})
+                 'labels':torch.tensor(train1_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(train2_input,dtype = torch.float32),
                  'labels':torch.tensor(train2_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(test1_input,dtype = torch.float32), 
@@ -119,7 +119,7 @@ def env_covariate_shift_EMNIST():
     envs = []
 
     envs.append({'images':torch.tensor(train1_input,dtype = torch.float32), 
-                 'labels':torch.tensor(train2_label,dtype = torch.float32)})
+                 'labels':torch.tensor(train1_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(train2_input,dtype = torch.float32),
                  'labels':torch.tensor(train2_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(test1_input,dtype = torch.float32), 
@@ -147,7 +147,7 @@ def env_mechanism_shift_EMNIST():
     envs = []
 
     envs.append({'images':torch.tensor(train1_input,dtype = torch.float32), 
-                 'labels':torch.tensor(train2_label,dtype = torch.float32)})
+                 'labels':torch.tensor(train1_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(train2_input,dtype = torch.float32),
                  'labels':torch.tensor(train2_label,dtype = torch.float32)})
     envs.append({'images':torch.tensor(test1_input,dtype = torch.float32), 


### PR DESCRIPTION
Hi 

I was reading the code and I came up with this typo, thought that it should be changed to `train1_label` instead of `train2_label` in `make_envs.py` file.

great job btw
